### PR TITLE
add offsets for 13.3.1 (x86/arm64) + 13.5 (x86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A small service that generates iMessage registration data on a Mac. If you do no
 ## Supported MacOS versions
 The tool is currently quite hacky, so it only works on specific versions of macOS.
 
-* Intel: 11.5 - 11.7, 14.0 - 14.3
-* Apple Silicon: 13.5 - 13.6, 14.0 - 14.3
+* Intel: 11.5 - 11.7, 13.3.1, 13.5 - 13.6, 14.0 - 14.3
+* Apple Silicon: 13.3.1, 13.5 - 13.6, 14.0 - 14.3
 
 On unsupported versions, it will tell you that it's unsupported and exit.
 A future version may work in less hacky ways to support more OS versions.

--- a/nac/offsets.go
+++ b/nac/offsets.go
@@ -14,13 +14,40 @@ var offsets_11_7_7 = imdOffsetTuple{x86: imdOffsets{
 	NACSignAddress:             0x3c71a0,
 }}
 
-var offsets_13_6 = imdOffsetTuple{arm64: imdOffsets{
-	ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
-	ReferenceAddress:           0xb524c,
-	NACInitAddress:             0x41d714,
-	NACKeyEstablishmentAddress: 0x40af78,
-	NACSignAddress:             0x3e5184,
-}}
+var offsets_13_3_1 = imdOffsetTuple{
+	x86: imdOffsets{
+		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
+		ReferenceAddress:           0xccfdf,
+		NACInitAddress:             0x4ac060,
+		NACKeyEstablishmentAddress: 0x48c0a0,
+		NACSignAddress:             0x49f390,
+	},
+	arm64: imdOffsets{
+		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
+		ReferenceAddress:           0xb7570,
+		NACInitAddress:             0x414e28,
+		NACKeyEstablishmentAddress: 0x40268c,
+		NACSignAddress:             0x3dc898,
+	},
+}
+
+// Offsets from the macOS 13.5 binary, works on 13.5 - 13.6
+var offsets_13_6 = imdOffsetTuple{
+	x86: imdOffsets{
+		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
+		ReferenceAddress:           0xcc743,
+		NACInitAddress:             0x4b91e0,
+		NACKeyEstablishmentAddress: 0x499220,
+		NACSignAddress:             0x4ac510,
+	},
+	arm64: imdOffsets{
+		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
+		ReferenceAddress:           0xb524c,
+		NACInitAddress:             0x41d714,
+		NACKeyEstablishmentAddress: 0x40af78,
+		NACSignAddress:             0x3e5184,
+	},
+}
 
 var offsets_14_0 = imdOffsetTuple{
 	x86: imdOffsets{
@@ -102,6 +129,8 @@ var offsets = map[[32]byte]imdOffsetTuple{
 	hexToByte32("6e8caf477c2b4d3a56a91835a2b6455f36fb0feb13006def7516ac09578c67d0"): {},
 	// macOS 13.2.1
 	hexToByte32("4d96de9438fdea5b0b7121e485541ecf0a74489eeb330c151a7d44d289dd3a85"): {},
+	// macOS 13.3.1
+	hexToByte32("3c8357aaa1df1eb3a21d88182a1a0fca1c612a4d63592e022ca65bbf47deee35"): offsets_13_3_1,
 	// macOS 13.5 - 13.6
 	hexToByte32("fff8db27fef2a2b874f7bc6fb303a98e3e3b8aceb8dd4c5bfa2bad7b76ea438a"): offsets_13_6,
 	// macOS 13.6.3


### PR DESCRIPTION
This PR adds the offsets extracted from the binaries on `13.3.1` (x86/arm64) + `13.5` (x86)

```bash
⇒ file macos*
macos-13.3.1-22E261-ventura-arm64-identityservicesd: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64e]
macos-13.3.1-22E261-ventura-arm64-identityservicesd (for architecture x86_64):	Mach-O 64-bit executable x86_64
macos-13.3.1-22E261-ventura-arm64-identityservicesd (for architecture arm64e):	Mach-O 64-bit executable arm64e

macos-13.5-22G74-ventura-x86-identityservicesd:      Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64e]
macos-13.5-22G74-ventura-x86-identityservicesd (for architecture x86_64):	Mach-O 64-bit executable x86_64
macos-13.5-22G74-ventura-x86-identityservicesd (for architecture arm64e):	Mach-O 64-bit executable arm64e
```

```bash
⇒ sha256sum  macos*

3c8357aaa1df1eb3a21d88182a1a0fca1c612a4d63592e022ca65bbf47deee35  macos-13.3.1-22E261-ventura-arm64-identityservicesd

fff8db27fef2a2b874f7bc6fb303a98e3e3b8aceb8dd4c5bfa2bad7b76ea438a  macos-13.5-22G74-ventura-x86-identityservicesd
```

---

I verified my process by first confirming I could find the same offsets that were already identified for the 14.2 binary (on both x86/arm64)

Sanity checked my found offsets by calculating the difference from `NACInitAddress` -> `NACKeyEstablishmentAddress` and `NACKeyEstablishmentAddress` -> `NACSignAddress` in the `14.2` binary (x86/arm64), and they match the differences between the offsets I calculated for the `13.3.1`/`13.5` binaries (x86/arm64).