### PR TITLE
Hardcode software_name to "macOS"

### DIFF
--- a/versions/versions.go
+++ b/versions/versions.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/tidwall/gjson"
 )
@@ -26,11 +25,8 @@ func (v *Versions) UserAgent() string {
 }
 
 func getSoftwareName() string {
-	softwareName, err := exec.Command("sw_vers", "-productName").Output()
-	if err != nil {
-		panic(fmt.Errorf("error running sw_vers: %w", err))
-	}
-	return strings.TrimSpace(string(softwareName))
+	// Hardcode the software_name to "macOS"
+	return "macOS"
 }
 
 func getSerialNumber() (serial, uuid string) {


### PR DESCRIPTION
- on macOS 10.15 and earlier, the software_name reports as "Mac OS X" and this breaks reteival of albert push cert causing Beeper Mini to crash after entering registration code.

macOS 11+ reports `software_name` as "macOS".

With software_name reporting as "Mac OS X" the following error can been seen in logcat:
```com.beeper.chat.booper.ipc.BridgeCrashedException: {"level":"fatal","error":"failed to generate albert push certificate: failed to decode device cert","time":"2023-12-28T12:58:40.124078741Z","message":"Failed to configure iMessage"}```

Once mac-registration-provider is re-built with the `software_name` "spoofed" to "macOS", the issue is gone and the app then prompts for Apple ID sign-in. 

It may be best to set this hardcoded value on the Beeper/Beeper Mini side of things... but, for now, this specific code change allows Beeper Mini to register while running this binary on macOS 10.15.x.

Additional changes in versions.go for macOS 10.14 and below will be needed as the current error handling with `panic` causes the binary to fail as the various commands to obtain hardware/software info fail on macOS 10.14 and earlier. 

