### PR TITLE
Use xml with system_profiler

### DIFF
--- a/versions/versions.go
+++ b/versions/versions.go
@@ -37,7 +37,7 @@ func getSoftwareName() string {
 func getSerialNumber() (serial, uuid string) {
 	data, err := exec.Command("system_profiler", "SPHardwareDataType", "-json").Output()
 	if err != nil {
-		data, err = exec.Command("system_profiler", "SPHardwareDataType", "-xml").Output()
+		xmlData, err := exec.Command("system_profiler", "SPHardwareDataType", "-xml").Output()
 		if err != nil {
 			panic(fmt.Errorf("error running system_profiler: %w", err))
 		}

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -37,7 +37,7 @@ func getSoftwareName() string {
 func getSerialNumber() (serial, uuid string) {
 	data, err := exec.Command("system_profiler", "SPHardwareDataType", "-json").Output()
 	if err != nil {
-		output, err := exec.Command("system_profiler", "SPHardwareDataType", "-xml").Output()
+		data, err := exec.Command("system_profiler", "SPHardwareDataType", "-xml").Output()
 		if err != nil {
 			panic(fmt.Errorf("error running system_profiler: %w", err))
 		}

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -35,7 +35,7 @@ func getSoftwareName() string {
 }
 
 func getSerialNumber() (serial, uuid string) {
-	data, err = exec.Command("system_profiler", "SPHardwareDataType", "-json").Output()
+	data, err := exec.Command("system_profiler", "SPHardwareDataType", "-json").Output()
 	if err != nil {
 		data, err = exec.Command("system_profiler", "SPHardwareDataType", "-xml").Output()
 		if err != nil {

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -37,7 +37,7 @@ func getSoftwareName() string {
 func getSerialNumber() (serial, uuid string) {
 	data, err := exec.Command("system_profiler", "SPHardwareDataType", "-json").Output()
 	if err != nil {
-		xmlData, err := exec.Command("system_profiler", "SPHardwareDataType", "-xml").Output()
+		output, err := exec.Command("system_profiler", "SPHardwareDataType", "-xml").Output()
 		if err != nil {
 			panic(fmt.Errorf("error running system_profiler: %w", err))
 		}


### PR DESCRIPTION
- fallback to -xml if macOS version does not include -json

This fixes issues on macOS 10.14.x (Mojave) and earlier as system_profiler does not offer `-json` option until 10.15.x (Catalina). 

I would assume usage on 10.14.x and earlier will be less than 10.15.x so I thought it'd be best to leave the json parsing in rather than switch entirely to xml. Could also have conditions depending on macOS version detected but current method in this PR seemed more straightforward. 