### PR TITLE
Add "pre-Catalina" support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,7 +41,7 @@ jobs:
           if-no-files-found: error
 
   build-x86:
-    runs-on: macos-13
+    runs-on: macos-11
 
     steps:
       - uses: actions/checkout@v3

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/tidwall/gjson"
@@ -36,10 +37,20 @@ func getSoftwareName() string {
 func getSerialNumber() (serial, uuid string) {
 	data, err := exec.Command("system_profiler", "SPHardwareDataType", "-json").Output()
 	if err != nil {
-		panic(fmt.Errorf("error running system_profiler: %w", err))
+		out, err := exec.Command("system_profiler", "SPHardwareDataType", "-xml").Output()
+		if err != nil {
+			panic(fmt.Errorf("error running system_profiler: %w", err))
+		}
+		serialRegex := regexp.MustCompile("<key>serial_number</key>\\s*<string>([^<]*)</string>")
+		uuidRegex := regexp.MustCompile("<key>platform_UUID</key>\\s*<string>([^<]*)</string>")
+
+		serial = serialRegex.FindStringSubmatch(string(out))[1]
+		uuid = uuidRegex.FindStringSubmatch(string(out))[1]
+	} else {
+		serial = gjson.GetBytes(data, "SPHardwareDataType.0.serial_number").Str
+		uuid = gjson.GetBytes(data, "SPHardwareDataType.0.platform_UUID").Str
 	}
-	return gjson.GetBytes(data, "SPHardwareDataType.0.serial_number").Str,
-		gjson.GetBytes(data, "SPHardwareDataType.0.platform_UUID").Str
+	return serial, uuid
 }
 
 func getHostname() string {

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -41,8 +41,8 @@ func getSerialNumber() (serial, uuid string) {
 		if err != nil {
 			panic(fmt.Errorf("error running system_profiler: %w", err))
 		}
-		serialRegex := regexp.MustCompile("<key>serial_number</key>\\s*<string>([^<]*)</string>")
-		uuidRegex := regexp.MustCompile("<key>platform_UUID</key>\\s*<string>([^<]*)</string>")
+		serialRegex := regexp.MustCompile(`<key>serial_number</key>\s*<string>([^<]*)</string>`)
+		uuidRegex := regexp.MustCompile(`<key>platform_UUID</key>\s*<string>([^<]*)</string>`)
 
 		serial = serialRegex.FindStringSubmatch(string(out))[1]
 		uuid = uuidRegex.FindStringSubmatch(string(out))[1]


### PR DESCRIPTION
- fall back to regex to pull serial_number and platform_UUID output from system_profiler if -json option is not supported
- use macOS 11 runner to build for x86_64 to support macOS 10.14+ (and earlier?)

This PR coincides with:
- https://github.com/beeper/imessage/pull/11
- https://github.com/beeper/mac-registration-provider/pull/12

macOS 10.14.x and earlier do not support the `-json` flag when using system_profiler so switching to `-xml` and grabbing serial and UUID with regex has worked for me on 10.14.6. Additionally, when building the binary with macOS 13, the binary will not execute on macOS 10.14.x (and earlier) -- building on macOS 11 resolves this and does not cause any issues with current macOS builds that I am aware of. 

Parsing XML in Go was bothersome... though perhaps may be the more "proper" solution instead of regex. Alternatively, ioreg can be used to grab both serial and uuid:
- `ioreg -c IOPlatformExpertDevice -d 2 | awk -F\" '/IOPlatformSerialNumber/{print $(NF-1)}'`
- `ioreg -c IOPlatformExpertDevice -d 2 | awk -F\" '/IOPlatformUUID/{print $(NF-1)}'`
