### PR TITLE
add offsets for 12.7.1 (x86/arm64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ registration code and use it in Beeper Mini.
 ## Supported MacOS versions
 The tool is currently quite hacky, so it only works on specific versions of macOS.
 
-* Intel: 11.5 - 11.7, 13.3.1, 13.5 - 13.6, 14.0 - 14.3
-* Apple Silicon: 13.3.1, 13.5 - 13.6, 14.0 - 14.3
+* Intel: 11.5 - 11.7, 12.7.1, 13.3.1, 13.5 - 13.6, 14.0 - 14.3
+* Apple Silicon: 12.7.1, 13.3.1, 13.5 - 13.6, 14.0 - 14.3
 
 On unsupported versions, it will tell you that it's unsupported and exit.
 A future version may work in less hacky ways to support more OS versions.

--- a/nac/offsets.go
+++ b/nac/offsets.go
@@ -14,6 +14,23 @@ var offsets_11_7_7 = imdOffsetTuple{x86: imdOffsets{
 	NACSignAddress:             0x3c71a0,
 }}
 
+var offsets_12_7_1 = imdOffsetTuple{
+	x86: imdOffsets{
+		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
+		ReferenceAddress:           0xb2278,
+		NACInitAddress:             0x4132e0,
+		NACKeyEstablishmentAddress: 0x465e00,
+		NACSignAddress:             0x405c10,
+	},
+	arm64: imdOffsets{
+		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
+		ReferenceAddress:           0x0b562c,
+		NACInitAddress:             0x43d408,
+		NACKeyEstablishmentAddress: 0x3fdafc,
+		NACSignAddress:             0x3f2844,
+	},
+}
+
 var offsets_13_3_1 = imdOffsetTuple{
 	x86: imdOffsets{
 		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
@@ -127,6 +144,8 @@ var offsets = map[[32]byte]imdOffsetTuple{
 	hexToByte32("80107d249088d9762ec38c8f86d6797b5070d476377e7c5ddacf83ad32d00a1e"): offsets_11_7_7,
 	// macOS 12.6.3
 	hexToByte32("6e8caf477c2b4d3a56a91835a2b6455f36fb0feb13006def7516ac09578c67d0"): {},
+	// macOS 12.7.1
+	hexToByte32("5833338da6350266eda33f5501c5dfc793e0632b52883aa2389c438c02d03718"): offsets_12_7_1,
 	// macOS 13.2.1
 	hexToByte32("4d96de9438fdea5b0b7121e485541ecf0a74489eeb330c151a7d44d289dd3a85"): {},
 	// macOS 13.3.1


### PR DESCRIPTION
This PR adds the offsets extracted from the binary on `12.7.1` (x86/arm64)

```bash
⇒ file samples/macos-12.7.1-monterey-identityservicesd
samples/macos-12.7.1-monterey-identityservicesd: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64e]
samples/macos-12.7.1-monterey-identityservicesd (for architecture x86_64):	Mach-O 64-bit executable x86_64
samples/macos-12.7.1-monterey-identityservicesd (for architecture arm64e):	Mach-O 64-bit executable arm64e
```

```bash
⇒ sha256sum samples/macos-12.7.1-monterey-identityservicesd
5833338da6350266eda33f5501c5dfc793e0632b52883aa2389c438c02d03718  samples/macos-12.7.1-monterey-identityservicesd
```

---

Originally shared in this comment:

> > If you do end up finding them manually or something, could you please update the provider or post them here (because might as well if you already did the work and also I kind of want to be able to use that mac.....)
> 
> Yeah, absolutely. See below for the offsets I reversed this morning, and I will double check them a bit later + open a PR to have them added to this tool. They should be correct, but I want to be triple sure before I submit a PR with them.
> 
> ---
> 
> > It looks like my current 'automatically find the offsets' code doesn't fully work on that version of `identityservicesd` from macOS Monterey `12.7.1`:
> 
> Manually reversing the offsets (assuming I didn't make a mistake):
> 
> ## `samples/macos-12.7.1-monterey-identityservicesd`
> 
> `sha256`: `5833338da6350266eda33f5501c5dfc793e0632b52883aa2389c438c02d03718`
> 
> ### x86
> 
> `IDSProtoKeyTransparencyTrustedServiceReadFrom`: `0xb2278` (`0x1000b2278`)
> `nac_init`: `0x4132e0` (`0x1004132e0`)
> `nac_key_establishment`: `0x465e00` (`0x100465e00`)
> `nac_sign`: `0x405c10` (`0x100405c10`)
> 
> ### arm64
> 
> `IDSProtoKeyTransparencyTrustedServiceReadFrom`: `0x0b562c` (`0x1000b562c`)
> `nac_init`: `0x43d408` (`0x10043d408`) (??? auto tool found this, but don't think it's correct.. `0x5897bc` (`0x1005897bc`) ???)
> `nac_key_establishment`: `0x3fdafc` (`0x1003fdafc`)
> `nac_sign`: `0x3f2844` (`0x1003f2844`)
> 
> ---
> 
> I'll see if I can use this to refine the patterns used in `find_fat_binary_offsets.py`
> 
> _Originally posted by @0xdevalias in https://github.com/beeper/mac-registration-provider/issues/9#issuecomment-1872428661_

For verification, this method may allow acquiring the relevant binary versions:

> Curious, how do you have access to the older binaries? Extracting them from Time Machine backups/similar, or?
> 
> _Originally posted by @0xdevalias in https://github.com/beeper/mac-registration-provider/pull/12#discussion_r1440069330_

> Downloading macOS and extracting the binary for each version. 
> 
> https://github.com/corpnewt/gibMacOS
> https://support.apple.com/kb/DL2052
> etc
> 
> _Originally posted by @jetfir3 in https://github.com/beeper/mac-registration-provider/pull/12#discussion_r1440476750_