### PR TITLE
Add new offsets for the newest 14.3 beta build.

### DIFF
--- a/nac/offsets.go
+++ b/nac/offsets.go
@@ -103,17 +103,17 @@ var offsets_14_2 = imdOffsetTuple{
 var offsets_14_3 = imdOffsetTuple{
 	x86: imdOffsets{
 		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
-		ReferenceAddress:           0xd45d9,
-		NACInitAddress:             0x54c660,
-		NACKeyEstablishmentAddress: 0x52c6a0,
-		NACSignAddress:             0x53f990,
+		ReferenceAddress:           0xd4d39,
+		NACInitAddress:             0x54c6c0,
+		NACKeyEstablishmentAddress: 0x52c700,
+		NACSignAddress:             0x53f9f0,
 	},
 	arm64: imdOffsets{
 		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
-		ReferenceAddress:           0xbd6f4,
-		NACInitAddress:             0x4b54e0,
-		NACKeyEstablishmentAddress: 0x4a2d44,
-		NACSignAddress:             0x47cf50,
+		ReferenceAddress:           0xbdbdc,
+		NACInitAddress:             0x4b5590,
+		NACKeyEstablishmentAddress: 0x4a2df4,
+		NACSignAddress:             0x47d000,
 	},
 }
 
@@ -144,7 +144,7 @@ var offsets = map[[32]byte]imdOffsetTuple{
 	// macOS 14.2
 	hexToByte32("034fc179e1cce559931a8e46866f54154cb1c5413902319473537527a2702b64"): offsets_14_2,
 	// macOS 14.3
-	hexToByte32("5b50140c83131b4f4bc32f5eb0679cf0763d41d3bfc4cc1c7a67e9c95779dc24"): offsets_14_3,
+	hexToByte32("1bb81b44add0f5f94a6b2abc0560fd3b6958667aad17208622163b16d35c7637"): offsets_14_3,
 }
 
 type imdOffsetTuple struct {

--- a/nac/offsets.go
+++ b/nac/offsets.go
@@ -182,7 +182,24 @@ var offsets_14_2 = imdOffsetTuple{
 	},
 }
 
-var offsets_14_3 = imdOffsetTuple{
+var offsets_14_3_b1 = imdOffsetTuple{
+	x86: imdOffsets{
+		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
+		ReferenceAddress:           0xd45d9,
+		NACInitAddress:             0x54c660,
+		NACKeyEstablishmentAddress: 0x52c6a0,
+		NACSignAddress:             0x53f990,
+	},
+	arm64: imdOffsets{
+		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
+		ReferenceAddress:           0xbd6f4,
+		NACInitAddress:             0x4b54e0,
+		NACKeyEstablishmentAddress: 0x4a2d44,
+		NACSignAddress:             0x47cf50,
+	},
+}
+
+var offsets_14_3_b2 = imdOffsetTuple{
 	x86: imdOffsets{
 		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
 		ReferenceAddress:           0xd4d39,
@@ -243,8 +260,10 @@ var offsets = map[[32]byte]imdOffsetTuple{
 	hexToByte32("47aa51e63ced0bb00dd27dab0def6f065a1a4911e250b79761681865fbd03644"): offsets_14_1,
 	// macOS 14.2
 	hexToByte32("034fc179e1cce559931a8e46866f54154cb1c5413902319473537527a2702b64"): offsets_14_2,
-	// macOS 14.3
-	hexToByte32("1bb81b44add0f5f94a6b2abc0560fd3b6958667aad17208622163b16d35c7637"): offsets_14_3,
+	// macOS 14.3 (older beta) TODO remove betas after release
+	hexToByte32("5b50140c83131b4f4bc32f5eb0679cf0763d41d3bfc4cc1c7a67e9c95779dc24"): offsets_14_3_b1,
+	// macOS 14.3 (newer beta)
+	hexToByte32("1bb81b44add0f5f94a6b2abc0560fd3b6958667aad17208622163b16d35c7637"): offsets_14_3_b2,
 }
 
 type imdOffsetTuple struct {


### PR DESCRIPTION
cameronaaron:beeper.com pulled the offsets for me. Tested on the newest 14.3 beta build (23D5043d). I overwrote the old 14.3 offsets since I believe no one would need us to support the older beta build, but please correct me if I'm wrong about that. 