### PR TITLE
add 14.4 beta offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ registration code and use it in Beeper Mini.
 ## Supported MacOS versions
 The tool is currently quite hacky, so it only works on specific versions of macOS.
 
-* Intel: 10.14.6, 10.15.1 - 10.15.7, 11.5 - 11.7, 12.7.1, 13.3.1, 13.5 - 13.6.4, 14.0 - 14.3
-* Apple Silicon: 12.7.1, 13.3.1, 13.5 - 13.6.4, 14.0 - 14.3
+* Intel: 10.14.6, 10.15.1 - 10.15.7, 11.5 - 11.7, 12.7.1, 13.3.1, 13.5 - 13.6.4, 14.0 - 14.3, 14.4 (beta)
+* Apple Silicon: 12.7.1, 13.3.1, 13.5 - 13.6.4, 14.0 - 14.3, 14.4 (beta)
 
 On unsupported versions, it will tell you that it's unsupported and exit.
 A future version may work in less hacky ways to support more OS versions.

--- a/nac/offsets.go
+++ b/nac/offsets.go
@@ -200,6 +200,23 @@ var offsets_14_3 = imdOffsetTuple{
 	},
 }
 
+var offsets_14_4_beta = imdOffsetTuple{
+	x86: imdOffsets{
+		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
+		ReferenceAddress:           0x0d6715,
+		NACInitAddress:             0x557cd0,
+		NACKeyEstablishmentAddress: 0x537d10,
+		NACSignAddress:             0x54b000,
+	},
+	arm64: imdOffsets{
+		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
+		ReferenceAddress:           0x0c0b84,
+		NACInitAddress:             0x4c2468,
+		NACKeyEstablishmentAddress: 0x4afccc,
+		NACSignAddress:             0x489ed8,
+	},
+}
+
 // offsets is a map from sha256 hash of identityservicesd to the function pointer offsets in that binary.
 var offsets = map[[32]byte]imdOffsetTuple{
 	// macOS 10.13.6
@@ -250,6 +267,8 @@ var offsets = map[[32]byte]imdOffsetTuple{
 	hexToByte32("034fc179e1cce559931a8e46866f54154cb1c5413902319473537527a2702b64"): offsets_14_2,
 	// macOS 14.3
 	hexToByte32("d3c6986fefcbd2efea2a8a7c88104bf22d60d1f4f2bbf3615a1e3ce098aba765"): offsets_14_3,
+	// macOS 14.4 beta ??
+	hexToByte32("5b4fc94e11555b628161ca1e5c4c14f8b3350fb28d0b513f4b6875ecce3b06ee"): offsets_14_4_beta,
 }
 
 type imdOffsetTuple struct {


### PR DESCRIPTION
Adds the offsets for the 14.4 beta binary provided in the following issue.

- Closes https://github.com/beeper/mac-registration-provider/issues/34

These offsets were automatically extracted using my finder tooling, and I haven't tested/manually verified them:

- https://github.com/beeper/mac-registration-provider/issues/9
- https://github.com/0xdevalias/poc-re-binsearch/blob/main/find_fat_binary_offsets.py