### PR TITLE
Update offsets.go to support macOS 14.4.1

### DIFF
--- a/nac/offsets.go
+++ b/nac/offsets.go
@@ -200,6 +200,23 @@ var offsets_14_3 = imdOffsetTuple{
 	},
 }
 
+var offsets_14_4_1 = imdOffsetTuple{
+	x86: imdOffsets{
+		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
+		ReferenceAddress:           0x0d6715,
+		NACInitAddress:             0x557cd0,
+		NACKeyEstablishmentAddress: 0x537d10,
+		NACSignAddress:             0x54b000,
+	},
+	arm64: imdOffsets{
+		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",
+		ReferenceAddress:           0x0c0b84,
+		NACInitAddress:             0x4c2468,
+		NACKeyEstablishmentAddress: 0x4afccc,
+		NACSignAddress:             0x489ed8,
+	},
+}
+
 // offsets is a map from sha256 hash of identityservicesd to the function pointer offsets in that binary.
 var offsets = map[[32]byte]imdOffsetTuple{
 	// macOS 10.13.6
@@ -250,6 +267,8 @@ var offsets = map[[32]byte]imdOffsetTuple{
 	hexToByte32("034fc179e1cce559931a8e46866f54154cb1c5413902319473537527a2702b64"): offsets_14_2,
 	// macOS 14.3
 	hexToByte32("d3c6986fefcbd2efea2a8a7c88104bf22d60d1f4f2bbf3615a1e3ce098aba765"): offsets_14_3,
+	// macOS 14.4.1
+	hexToByte32("b82c5c6c9010a42cb64397e3760dd31144cbd471126111de9bb27fa3d2d2639a"): offsets_14_4_1,
 }
 
 type imdOffsetTuple struct {

--- a/nac/offsets.go
+++ b/nac/offsets.go
@@ -200,6 +200,7 @@ var offsets_14_3 = imdOffsetTuple{
 	},
 }
 
+// macOS 14.4.1
 var offsets_14_4_1 = imdOffsetTuple{
 	x86: imdOffsets{
 		ReferenceSymbol:            "IDSProtoKeyTransparencyTrustedServiceReadFrom",


### PR DESCRIPTION
It was unable to find offsets in my Mac. so I updated it to support my Mac.

```sh
>>> ./mac-registration-provider
2024/04/07 13:42:25 Starting mac-registration-provider 31dc297a
2024/04/07 13:42:25 Loading identityservicesd
2024/04/07 13:42:25 No offsets found for 14.4.1/23E224/amd64 (hash: b82c5c6c9010a42cb64397e3760dd31144cbd471126111de9bb27fa3d2d2639a)
```

```sh
>>> python find_fat_binary_offsets.py /System/Library/PrivateFrameworks/IDS.framework/identityservicesd.app/Contents/MacOS/identityservicesd 
-= Universal Binary Sections =-
Architecture 0 (x86_64):
  CPU Type: 16777223 (0x1000007)
  CPU Subtype: 3 (0x3)
  CPU Subtype Capability: 0 (0x0)
  Offset: 0x4000 (Valid Mach-O Header: Yes)
  Size: 8880384
  Align: 14
Architecture 1 (arm64e):
  CPU Type: 16777228 (0x100000c)
  CPU Subtype: 2 (0x2)
  CPU Subtype Capability: 128 (0x80)
  Offset: 0x880000 (Valid Mach-O Header: Yes)
  Size: 9865136
  Align: 14

-= Found Symbol Offsets =-
Offset of _IDSProtoKeyTransparencyTrustedServiceReadFrom in architecture x86_64: 0x0d6715
Offset of _IDSProtoKeyTransparencyTrustedServiceReadFrom in architecture arm64e: 0x0c0b84

-= Found Hex Offsets (with pure python fixed sequence search + regex) =-
Architecture 0 (x86_64):
  IDSProtoKeyTransparencyTrustedServiceReadFrom: 0xd6715
  NACInitAddress: 0x557cd0
  NACKeyEstablishmentAddress: 0x537d10
  NACSignAddress: 0x54b000
Architecture 1 (arm64e):
  IDSProtoKeyTransparencyTrustedServiceReadFrom: 0xc0b84; 0x2f5d0c; 0x322dac; 0x33a660
  NACInitAddress: 0x4c2468
  NACKeyEstablishmentAddress: 0x4afccc
  NACSignAddress: 0x489ed8
```